### PR TITLE
Resolve possible race

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.0.24: QmXSQk5GwXeQVmeeoH64hEqCip584MYdbwhMF7tJ1jSbq3
+1.0.24: QmPYiV9nwnXPxdn9zDgY4d9yaHwTS414sUb1K6nvQVHqqo

--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.0.23: Qmas5ivzqmatd1tJWppjcupYY8YS2DJHJZxSMsMoLbCQ2R
+1.0.24: QmXSQk5GwXeQVmeeoH64hEqCip584MYdbwhMF7tJ1jSbq3

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ deps: gx
 	gx --verbose install --global
 	gx-go rewrite
 test: deps
-	go test -v -covermode=atomic -coverprofile=coverage.txt .
+	go test -v -race -covermode=atomic -coverprofile=coverage.txt .
 rw:
 	gx-go rewrite
 rwundo:

--- a/call.go
+++ b/call.go
@@ -96,3 +96,9 @@ func (call *Call) setError(err error) {
 		call.Error = err
 	}
 }
+
+func (call *Call) getError() error {
+	call.errorMu.Lock()
+	defer call.errorMu.Unlock()
+	return call.Error
+}

--- a/client.go
+++ b/client.go
@@ -75,7 +75,7 @@ func (c *Client) CallContext(
 	call := newCall(ctx, dest, svcName, svcMethod, args, reply, done)
 	go c.makeCall(call)
 	<-done
-	return call.Error
+	return call.getError()
 }
 
 // Go performs an RPC call asynchronously. The associated Call will be placed

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "license": "MIT/BSD",
   "name": "go-libp2p-gorpc",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.0.23"
+  "version": "1.0.24"
 }
 


### PR DESCRIPTION
When a call dies badly, we cancel the context and that attempts
to set the error. We probably should not set that error at all
since it will likely overwrite the original and at worse
cause a race. This fixes that and also adds getError() to
avoid a race altogether.