### PR TITLE
Permissioned RPC endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,17 +5,18 @@ import (
 	"io"
 	"sync"
 
-	stats "github.com/libp2p/go-libp2p-gorpc/stats"
 	host "github.com/libp2p/go-libp2p-host"
 	inet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
 	protocol "github.com/libp2p/go-libp2p-protocol"
+
+	stats "github.com/libp2p/go-libp2p-gorpc/stats"
 )
 
 // ClientOption allows for functional setting of options on a Client.
 type ClientOption func(*Client)
 
-// WithClientStatsHandler providers a implementation of stats.Handler to be
+// WithClientStatsHandler provides an implementation of stats.Handler to be
 // used by the Client.
 func WithClientStatsHandler(h stats.Handler) ClientOption {
 	return func(c *Client) {

--- a/errors.go
+++ b/errors.go
@@ -13,7 +13,7 @@ const (
 	serverErr
 	// clientErr is an error that has arisen on the client side.
 	clientErr
-	// authErr is an error that has arisen because client doesn't
+	// authorizationErr is an error that has arisen because client doesn't
 	// have permissions to make the given rpc request
 	authorizationErr
 )
@@ -48,19 +48,19 @@ func newClientError(err error) error {
 	return &clientError{err.Error()}
 }
 
-// authError indicates that error originated because of client not having
+// authorizationError indicates that error originated because of client not having
 // permissions to make given rpc request
-type authError struct {
+type authorizationError struct {
 	msg string
 }
 
-func (a *authError) Error() string {
+func (a *authorizationError) Error() string {
 	return a.msg
 }
 
-// newAuthError wraps an error in the authError type.
-func newAuthError(err error) error {
-	return &authError{err.Error()}
+// newAuthorizationError wraps an error in the authorizationError type.
+func newAuthorizationError(err error) error {
+	return &authorizationError{err.Error()}
 }
 
 // responseError converts an responseErr and error message string
@@ -72,7 +72,7 @@ func responseError(errType responseErr, errMsg string) error {
 	case clientErr:
 		return &clientError{errMsg}
 	case authorizationErr:
-		return &authError{errMsg}
+		return &authorizationError{errMsg}
 	default:
 		return errors.New(errMsg)
 	}
@@ -87,7 +87,7 @@ func responseErrorType(err error) responseErr {
 		return serverErr
 	case *clientError:
 		return clientErr
-	case *authError:
+	case *authorizationError:
 		return authorizationErr
 	default:
 		return nonRPCErr
@@ -98,7 +98,7 @@ func responseErrorType(err error) responseErr {
 // or clientError.
 func IsRPCError(err error) bool {
 	switch err.(type) {
-	case *serverError, *clientError, *authError:
+	case *serverError, *clientError, *authorizationError:
 		return true
 	default:
 		return false
@@ -115,7 +115,7 @@ func IsClientError(err error) bool {
 	return responseErrorType(err) == clientErr
 }
 
-// IsAuthorizationError returns whether an error is authError.
+// IsAuthorizationError returns whether an error is authorizationError.
 func IsAuthorizationError(err error) bool {
 	return responseErrorType(err) == authorizationErr
 }

--- a/errors.go
+++ b/errors.go
@@ -15,7 +15,7 @@ const (
 	clientErr
 	// authErr is an error that has arisen because client doesn't
 	// have permissions to make the given rpc request
-	authErr
+	authorizationErr
 )
 
 // serverError indicates that error originated in server
@@ -71,7 +71,7 @@ func responseError(errType responseErr, errMsg string) error {
 		return &serverError{errMsg}
 	case clientErr:
 		return &clientError{errMsg}
-	case authErr:
+	case authorizationErr:
 		return &authError{errMsg}
 	default:
 		return errors.New(errMsg)
@@ -88,7 +88,7 @@ func responseErrorType(err error) responseErr {
 	case *clientError:
 		return clientErr
 	case *authError:
-		return authErr
+		return authorizationErr
 	default:
 		return nonRPCErr
 	}
@@ -115,7 +115,7 @@ func IsClientError(err error) bool {
 	return responseErrorType(err) == clientErr
 }
 
-// IsAuthError returns whether an error is authError.
-func IsAuthError(err error) bool {
-	return responseErrorType(err) == authErr
+// IsAuthorizationError returns whether an error is authError.
+func IsAuthorizationError(err error) bool {
+	return responseErrorType(err) == authorizationErr
 }

--- a/server.go
+++ b/server.go
@@ -233,7 +233,7 @@ func (server *Server) handle(s *streamWrap) error {
 
 	if server.authorize != nil && !server.authorize(s.stream.Conn().RemotePeer(), svcID.Name, svcID.Method) {
 		errMsg := fmt.Sprintf("client does not have permissions to this method, service name: %s, method name: %s", svcID.Name, svcID.Method)
-		return newAuthError(errors.New(errMsg))
+		return newAuthorizationError(errors.New(errMsg))
 	}
 
 	// Decode the argument value.

--- a/server.go
+++ b/server.go
@@ -106,7 +106,7 @@ type Response struct {
 // AuthorizeWithMap returns an authrorization function that follows the
 // strategy as described in the given map(maps "service.method" of a peer to
 // boolean permission).
-func AuthorizeWithMap(p map[peer.ID]map[string]bool) func(peer.ID, string, string) bool {
+func AuthorizeWithMap(p map[peer.ID]map[string]bool) func(pid peer.ID, svc string, method string) bool {
 	return func(pid peer.ID, svc string, method string) bool {
 		// If map is nil, no method would be allowed
 		if p == nil {

--- a/server.go
+++ b/server.go
@@ -233,7 +233,7 @@ func (server *Server) handle(s *streamWrap) error {
 
 	if server.authorize != nil && !server.authorize(s.stream.Conn().RemotePeer(), svcID.Name, svcID.Method) {
 		errMsg := fmt.Sprintf("client does not have permissions to this method, service name: %s, method name: %s", svcID.Name, svcID.Method)
-		return newServerError(errors.New(errMsg))
+		return newAuthError(errors.New(errMsg))
 	}
 
 	// Decode the argument value.

--- a/server_test.go
+++ b/server_test.go
@@ -485,6 +485,9 @@ func TestAuthorization(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error instead")
 	}
+	if !IsAuthError(err) {
+		t.Error("expected authorization error, but found", responseErrorType(err))
+	}
 	expectedErrMsg := "client does not have permissions to this method, service name: Arith, method name: Divide"
 	actualErrMsg := err.Error()
 	if actualErrMsg != expectedErrMsg {
@@ -495,6 +498,9 @@ func TestAuthorization(t *testing.T) {
 	err = c1.Call(dest, "Arith", "Multiply", &Args{2, 3}, &r)
 	if err == nil {
 		t.Fatal("expected error instead")
+	}
+	if !IsAuthError(err) {
+		t.Error("expected authorization error, but found", responseErrorType(err))
 	}
 	expectedErrMsg = "client does not have permissions to this method, service name: Arith, method name: Multiply"
 	actualErrMsg = err.Error()

--- a/server_test.go
+++ b/server_test.go
@@ -488,11 +488,6 @@ func TestAuthorization(t *testing.T) {
 	if !IsAuthError(err) {
 		t.Error("expected authorization error, but found", responseErrorType(err))
 	}
-	expectedErrMsg := "client does not have permissions to this method, service name: Arith, method name: Divide"
-	actualErrMsg := err.Error()
-	if actualErrMsg != expectedErrMsg {
-		t.Error("expected a different error, but found:", actualErrMsg)
-	}
 
 	c1 := NewClientWithServer(h3, "rpc", s)
 	err = c1.Call(dest, "Arith", "Multiply", &Args{2, 3}, &r)
@@ -501,11 +496,6 @@ func TestAuthorization(t *testing.T) {
 	}
 	if !IsAuthError(err) {
 		t.Error("expected authorization error, but found", responseErrorType(err))
-	}
-	expectedErrMsg = "client does not have permissions to this method, service name: Arith, method name: Multiply"
-	actualErrMsg = err.Error()
-	if actualErrMsg != expectedErrMsg {
-		t.Error("expected a different error, but found:", actualErrMsg)
 	}
 
 	// Authorization should not impact while accessing methods locally.

--- a/server_test.go
+++ b/server_test.go
@@ -485,7 +485,7 @@ func TestAuthorization(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error instead")
 	}
-	if !IsAuthError(err) {
+	if !IsAuthorizationError(err) {
 		t.Error("expected authorization error, but found", responseErrorType(err))
 	}
 
@@ -494,7 +494,7 @@ func TestAuthorization(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error instead")
 	}
-	if !IsAuthError(err) {
+	if !IsAuthorizationError(err) {
 		t.Error("expected authorization error, but found", responseErrorType(err))
 	}
 


### PR DESCRIPTION
It introduces an authorization function, which can be passed while
creating a new server. One such function is provided which uses a map
(maps "service.method" of a peer to boolean permission) to check
permissions. User can choose to use that function or a define a
new function as long as it follows the prescribed format.

It follows a whitelist approach(i.e., by default does not allow)
- If an authorization is not passed, server would not let any peer
access any methods

Fixes #35