### PR TITLE
gx publish 1.1.5

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.4: QmcJCApoEsCJJap2iS1os9GFX5EuRrfuPeZdjCopz2SyPm
+1.1.5: QmRJP3v36DnzJuXwk8U4PfXjEbqt3CidgntwtEuxoDcoSp

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "license": "MIT/BSD",
   "name": "go-libp2p-gorpc",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.1.4"
+  "version": "1.1.5"
 }
 


### PR DESCRIPTION
Version 1.1.4 did not have my changes.
I have pinned this using ipfs pinbot.
Let me know if anything else would be required.
This would cause some more bubbling