### PR TITLE
Make rpc call errors a warning.

### DIFF
--- a/call.go
+++ b/call.go
@@ -60,7 +60,7 @@ func (call *Call) done() {
 
 func (call *Call) doneWithError(err error) {
 	if err != nil {
-		logger.Error(err)
+		logger.Warning(err)
 		call.setError(err)
 	}
 	call.done()


### PR DESCRIPTION
Generally they should be logged upstream.