### PR TITLE
Streaming RPC methods support

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,20 +2,20 @@ package rpc
 
 import "errors"
 
-// responseErr is an enum type for providing error type
+// ErrorType is an enum type for providing error type
 // information over the wire between rpc server and client.
-type responseErr int
+type ErrorType int
 
 const (
-	// nonRPCErr is an error that hasn't arisen from the gorpc package.
-	nonRPCErr responseErr = iota
-	// serverErr is an error that has arisen on the server side.
-	serverErr
-	// clientErr is an error that has arisen on the client side.
-	clientErr
-	// authorizationErr is an error that has arisen because client doesn't
+	// NonRPCErr is an error that hasn't arisen from the gorpc package.
+	NonRPCErr ErrorType = iota
+	// ServerErr is an error that has arisen on the server side.
+	ServerErr
+	// ClientErr is an error that has arisen on the client side.
+	ClientErr
+	// AuthorizationErr is an error that has arisen because client doesn't
 	// have permissions to make the given rpc request
-	authorizationErr
+	AuthorizationErr
 )
 
 // serverError indicates that error originated in server
@@ -65,13 +65,13 @@ func newAuthorizationError(err error) error {
 
 // responseError converts an responseErr and error message string
 // into the appropriate error type.
-func responseError(errType responseErr, errMsg string) error {
+func responseError(errType ErrorType, errMsg string) error {
 	switch errType {
-	case serverErr:
+	case ServerErr:
 		return &serverError{errMsg}
-	case clientErr:
+	case ClientErr:
 		return &clientError{errMsg}
-	case authorizationErr:
+	case AuthorizationErr:
 		return &authorizationError{errMsg}
 	default:
 		return errors.New(errMsg)
@@ -81,16 +81,16 @@ func responseError(errType responseErr, errMsg string) error {
 // responseErrorType determines whether an error is of either
 // serverError or clientError type and returns the appropriate
 // responseErr value.
-func responseErrorType(err error) responseErr {
+func responseErrorType(err error) ErrorType {
 	switch err.(type) {
 	case *serverError:
-		return serverErr
+		return ServerErr
 	case *clientError:
-		return clientErr
+		return ClientErr
 	case *authorizationError:
-		return authorizationErr
+		return AuthorizationErr
 	default:
-		return nonRPCErr
+		return NonRPCErr
 	}
 }
 
@@ -107,15 +107,15 @@ func IsRPCError(err error) bool {
 
 // IsServerError returns whether an error is serverError.
 func IsServerError(err error) bool {
-	return responseErrorType(err) == serverErr
+	return responseErrorType(err) == ServerErr
 }
 
 // IsClientError returns whether an error is clientError.
 func IsClientError(err error) bool {
-	return responseErrorType(err) == clientErr
+	return responseErrorType(err) == ClientErr
 }
 
 // IsAuthorizationError returns whether an error is authorizationError.
 func IsAuthorizationError(err error) bool {
-	return responseErrorType(err) == authorizationErr
+	return responseErrorType(err) == AuthorizationErr
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-libp2p-gorpc
 
-go 1.16
+go 1.17
 
 require (
 	github.com/ipfs/go-log/v2 v2.5.0
@@ -8,4 +8,104 @@ require (
 	github.com/libp2p/go-libp2p-core v0.13.0
 	github.com/multiformats/go-multiaddr v0.4.0
 	github.com/ugorji/go/codec v1.2.6
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/btcsuite/btcd v0.22.0-beta // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cheekybits/genny v1.0.0 // indirect
+	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
+	github.com/flynn/noise v1.0.0 // indirect
+	github.com/francoispqt/gojay v1.2.13 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/gopacket v1.1.19 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/huin/goupnp v1.0.2 // indirect
+	github.com/ipfs/go-cid v0.0.7 // indirect
+	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
+	github.com/ipfs/go-log v1.0.5 // indirect
+	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
+	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
+	github.com/klauspost/compress v1.11.7 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	github.com/koron/go-ssdp v0.0.2 // indirect
+	github.com/libp2p/go-addr-util v0.1.0 // indirect
+	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
+	github.com/libp2p/go-cidranger v1.1.0 // indirect
+	github.com/libp2p/go-conn-security-multistream v0.3.0 // indirect
+	github.com/libp2p/go-eventbus v0.2.1 // indirect
+	github.com/libp2p/go-flow-metrics v0.0.3 // indirect
+	github.com/libp2p/go-libp2p-asn-util v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-autonat v0.7.0 // indirect
+	github.com/libp2p/go-libp2p-blankhost v0.3.0 // indirect
+	github.com/libp2p/go-libp2p-discovery v0.6.0 // indirect
+	github.com/libp2p/go-libp2p-mplex v0.4.1 // indirect
+	github.com/libp2p/go-libp2p-nat v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-noise v0.3.0 // indirect
+	github.com/libp2p/go-libp2p-peerstore v0.6.0 // indirect
+	github.com/libp2p/go-libp2p-pnet v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-quic-transport v0.15.2 // indirect
+	github.com/libp2p/go-libp2p-swarm v0.9.0 // indirect
+	github.com/libp2p/go-libp2p-tls v0.3.1 // indirect
+	github.com/libp2p/go-libp2p-transport-upgrader v0.6.0 // indirect
+	github.com/libp2p/go-libp2p-yamux v0.7.0 // indirect
+	github.com/libp2p/go-maddr-filter v0.1.0 // indirect
+	github.com/libp2p/go-mplex v0.3.0 // indirect
+	github.com/libp2p/go-msgio v0.1.0 // indirect
+	github.com/libp2p/go-nat v0.1.0 // indirect
+	github.com/libp2p/go-netroute v0.1.6 // indirect
+	github.com/libp2p/go-openssl v0.0.7 // indirect
+	github.com/libp2p/go-reuseport v0.1.0 // indirect
+	github.com/libp2p/go-reuseport-transport v0.1.0 // indirect
+	github.com/libp2p/go-sockaddr v0.1.1 // indirect
+	github.com/libp2p/go-stream-muxer-multistream v0.3.0 // indirect
+	github.com/libp2p/go-tcp-transport v0.4.0 // indirect
+	github.com/libp2p/go-ws-transport v0.5.0 // indirect
+	github.com/libp2p/go-yamux/v2 v2.3.0 // indirect
+	github.com/lucas-clemente/quic-go v0.24.0 // indirect
+	github.com/marten-seemann/qtls-go1-16 v0.1.4 // indirect
+	github.com/marten-seemann/qtls-go1-17 v0.1.0 // indirect
+	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/miekg/dns v1.1.43 // indirect
+	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
+	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
+	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
+	github.com/minio/sha256-simd v1.0.0 // indirect
+	github.com/mr-tron/base58 v1.2.0 // indirect
+	github.com/multiformats/go-base32 v0.0.3 // indirect
+	github.com/multiformats/go-base36 v0.1.0 // indirect
+	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
+	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
+	github.com/multiformats/go-multibase v0.0.3 // indirect
+	github.com/multiformats/go-multihash v0.0.15 // indirect
+	github.com/multiformats/go-multistream v0.2.2 // indirect
+	github.com/multiformats/go-varint v0.0.6 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/onsi/ginkgo v1.16.4 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.30.0 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
+	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.7.0 // indirect
+	go.uber.org/zap v1.19.1 // indirect
+	golang.org/x/crypto v0.0.0-20210813211128-0a44fdfbc16e // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 // indirect
+	golang.org/x/tools v0.1.5 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/stream_wrap.go
+++ b/stream_wrap.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"bufio"
+	"io"
 
 	"github.com/libp2p/go-libp2p-core/network"
 
@@ -15,6 +16,7 @@ type streamWrap struct {
 	stream network.Stream
 	enc    *codec.Encoder
 	dec    *codec.Decoder
+	limDec *codec.Decoder
 	w      *bufio.Writer
 	r      *bufio.Reader
 }
@@ -29,6 +31,7 @@ func wrapStream(s network.Stream) *streamWrap {
 	writer := bufio.NewWriter(s)
 	h := &codec.MsgpackHandle{}
 	dec := codec.NewDecoder(reader, h)
+	limDec := codec.NewDecoder(&io.LimitedReader{R: reader, N: MaxServiceIDLength + 30}, h)
 	enc := codec.NewEncoder(writer, h)
 	return &streamWrap{
 		stream: s,
@@ -36,6 +39,7 @@ func wrapStream(s network.Stream) *streamWrap {
 		w:      writer,
 		enc:    enc,
 		dec:    dec,
+		limDec: limDec,
 	}
 
 }


### PR DESCRIPTION
This PR adds support for streaming RPC, meaning that servers can now register a method like:

func (s *Service) MyMethod(ctx, in chan Type1, out chan Type2) error

And we will be able to move data from client to servers and back without the
limitations of regular calls, namely:

- Not having to send everything before a response is obtained
- Not having to read all the response and put on memory before it is sent back.

The client can now call Stream(...) and MultiStream(...) to make use of these
methods.

Fixes https://github.com/libp2p/go-libp2p-gorpc/issues/8