### PR TITLE
Fix: MultiStream panics when using Receive-only channel for out

### DIFF
--- a/client.go
+++ b/client.go
@@ -473,7 +473,7 @@ func (c *Client) MultiStream(
 }
 
 func makeChanSliceOf(typ reflect.Type, cap int, buffer int) reflect.Value {
-	chanSlice := reflect.MakeSlice(reflect.SliceOf(typ), 0, cap)
+	chanSlice := reflect.MakeSlice(reflect.SliceOf(reflect.ChanOf(reflect.BothDir, typ.Elem())), 0, cap)
 	for i := 0; i < cap; i++ {
 		chanSlice = reflect.Append(
 			chanSlice,


### PR DESCRIPTION
This fixes a panic when the channel passed in for receiving replies in
MultiStream() is receive-only. The underlying problem is that the channels
created as Reply channels for the multiplexed calls to Stream were of the same
type as the channel passed-in, but these channels are read from in order to
place all the items in the original "out" channel.

We had not seen this before as channels passed-in were normally bi-directional.